### PR TITLE
Add the points for the Second Challenge Deadline

### DIFF
--- a/external/second-challenge.yaml
+++ b/external/second-challenge.yaml
@@ -1,0 +1,39 @@
+scores:
+  - team: ABS
+    league_points: 12
+  - team: BPV
+    league_points: 12
+  - team: HAB
+    league_points: 12
+  - team: HAM
+    league_points: 12
+  - team: HAY
+    league_points: 12
+  - team: HRO
+    league_points: 12
+  - team: HZW
+    league_points: 12
+  - team: KEG
+    league_points: 12
+  - team: KEV
+    league_points: 12
+  - team: MAI
+    league_points: 12
+  - team: MDN
+    league_points: 12
+  - team: PSC
+    league_points: 12
+  - team: QMC
+    league_points: 12
+  - team: RGS
+    league_points: 12
+  - team: SHK
+    league_points: 12
+  - team: SOG
+    league_points: 12
+  - team: THS
+    league_points: 12
+  - team: TLC
+    league_points: 12
+  - team: WGS
+    league_points: 12


### PR DESCRIPTION
This should have the 19 teams as listed under the "2nd challenge point" column in the "Teams" tab of the [SR2025 Challenges spreadsheet](https://docs.google.com/spreadsheets/d/1NCrAw2prbuW_L4Xsalc9fDQhWobdpCzSnblPEbLxCGQ/edit?gid=282590052#gid=282590052).

If we decided to include teams that have completed the 3rd challenge points for the virtual league, we'll add them as late as possible (so not now).