### PR TITLE
Update match periods to reflect the end times in the day schedule

### DIFF
--- a/schedule.yaml
+++ b/schedule.yaml
@@ -5,10 +5,10 @@
 #
 # Matches are played within slots, set their lengths:
 match_slot_lengths:
-  pre: 60
+  pre: 60   # DO NOT CHANGE (messes up the desired start times of the league slots)
   match: 150
-  post: 60    # 90 after virtual league
-  total: 270  # 300 after virtual league
+  post: 90
+  total: 300
 #
 # Various staging related times, in seconds before the actual match start
 staging:
@@ -41,32 +41,32 @@ delays: []
 match_periods:
   league:
   - start_time: 2025-02-08 13:10:00+00:00
-    end_time: 2025-02-08 14:49:00+00:00   # 2025-02-08 15:00:00+00:00 after virtual league
+    end_time: 2025-02-08 15:00:00+00:00
     max_end_time: 2025-02-08 15:10:00+00:00
     description: Virtual league
 
 #
-  - start_time: 2025-04-12 11:24:00+01:00
-    end_time: 2025-04-12 12:38:00+01:00
-    max_end_time: 2025-04-12 12:40:00+01:00
+  - start_time: 2025-04-12 11:24:00+01:00   # 11:24 comes from 11:20 in the day schedule plus 5 minute buffer, minus the 60 second pre-match slot length
+    end_time: 2025-04-12 12:34:00+01:00
+    max_end_time: 2025-04-12 12:36:00+01:00
     description: Saturday league, morning
 
 #
   - start_time: 2025-04-12 13:24:00+01:00
-    end_time: 2025-04-12 14:38:00+01:00
-    max_end_time: 2025-04-12 14:40:00+01:00
+    end_time: 2025-04-12 14:34:00+01:00
+    max_end_time: 2025-04-12 14:35:00+01:00
     description: Saturday league, early afternoon
 
 #
   - start_time: 2025-04-12 15:14:00+01:00
-    end_time: 2025-04-12 15:58:00+01:00
-    max_end_time: 2025-04-12 16:00:00+01:00
+    end_time: 2025-04-12 15:54:00+01:00
+    max_end_time: 2025-04-12 15:54:00+01:00
     description: Saturday league, late afternoon
 
 #
   - start_time: 2025-04-13 10:24:00+01:00
-    end_time: 2025-04-13 11:58:00+01:00
-    max_end_time: 2025-04-13 12:00:00+01:00
+    end_time: 2025-04-13 11:55:00+01:00
+    max_end_time: 2025-04-13 11:55:00+01:00
     description: Sunday league, morning
 
 #


### PR DESCRIPTION
The match_slot_lengths have also been updated back to their pre virtual league timings.

End slot timings are based on the following number of expected matches in each league slot:
- Saturday morning - 15 matches
- Saturday early afternoon - 15 matches
- Saturday late afternoon - 9 matches
- Sunday morning - (up to) 19 matches

Note that all the extra space in league timings for delays was put into the Sunday morning slot in the day schedule.

Given the times are all the start of the match slot, I've estimated that robots will be out of the arena 5 minutes later. This is from 1 min (pre-match time) + 2.5 min (match length) + 1.5 min (scoring and getting robots out).

This 'robots out' time for each of the `max_end_time`'s will be the following:
- Saturday morning: 12:41. This is 1 minute after lunch is scheduled to start (delays are more likely in the first league slot and missing 1 minute of lunch feels fine to me)
- Saturday early afternoon: 14:40. This is the exact time the photo starts
- Saturday late afternoon: 15:59. This is 1 minute before tinker time is due to start (really don't want to eat into tinker time if a team has booked a slot at 16:00)
- Sunday morning: 12:00. This is the exact time lunch is due to start.
