### PR TITLE
Add third challenge deadline points

### DIFF
--- a/external/third-challenge.yaml
+++ b/external/third-challenge.yaml
@@ -1,5 +1,27 @@
 scores:
+  - team: ABS
+    league_points: 12
+  - team: CLY
+    league_points: 12
   - team: HAB
     league_points: 12
+  - team: HAM
+    league_points: 12
+  - team: HAY
+    league_points: 12
+  - team: HRO
+    league_points: 12
+  - team: HRS
+    league_points: 12
+  - team: KEG
+    league_points: 12
+  - team: MAI
+    league_points: 12
+  - team: MDN
+    league_points: 12
   - team: RGS
+    league_points: 12
+  - team: SHK
+    league_points: 12
+  - team: THS
     league_points: 12


### PR DESCRIPTION
Add the rest of the challenge points for the third challenge deadline. HAB and RGS had third challenge deadline points added before the virtual league.

Challenges spreadsheet to compare - https://docs.google.com/spreadsheets/d/1NCrAw2prbuW_L4Xsalc9fDQhWobdpCzSnblPEbLxCGQ/edit?gid=282590052#gid=282590052