### PR TITLE
Double the league points earned for phyiscal league matches

### DIFF
--- a/scoring/ranker.py
+++ b/scoring/ranker.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Collection, Mapping
+
+from league_ranker import LeaguePoints, RankedPosition, TZone
+from sr.comp.ranker import LeagueRanker
+from sr.comp.types import MatchId, MatchNumber
+
+FIRST_PHYSICAL_MATCH_NUMBER = MatchNumber(23)
+
+
+class Ranker(LeagueRanker):
+    def calc_ranked_points(
+        self,
+        positions: Mapping[RankedPosition, Collection[TZone]],
+        *,
+        disqualifications: Collection[TZone],
+        num_zones: int,
+        match_id: MatchId,
+    ) -> dict[TZone, LeaguePoints]:
+        points = super().calc_ranked_points(
+            positions,
+            disqualifications=disqualifications,
+            num_zones=num_zones,
+            match_id=match_id,
+        )
+
+        # Physical league matches are worth double for SR2025
+        _, match_number = match_id
+        if match_number >= FIRST_PHYSICAL_MATCH_NUMBER:
+            return {k: LeaguePoints(v * 2) for k, v in points.items()}
+
+        return points

--- a/scoring/tests/test_ranker.py
+++ b/scoring/tests/test_ranker.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+
+"""
+Tests for the points override logic.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest
+from typing import Collection, Mapping
+
+from league_ranker import RankedPosition, TZone
+from sr.comp.types import ArenaName, MatchNumber
+
+# Path hackery
+ROOT = pathlib.Path(__file__).parent.parent
+sys.path.insert(0, str(ROOT))
+
+from ranker import Ranker  # type: ignore[import-not-found]  # noqa: E402
+
+
+class RankerTests(unittest.TestCase):
+    def assertPoints(
+        self,
+        expected_points: dict[TZone, int],
+        positions: Mapping[int, Collection[TZone]],
+        *,
+        disqualifications: Collection[TZone] = (),
+        match_num: int,
+    ) -> None:
+        ranker = Ranker()
+        actual_points = ranker.calc_ranked_points(
+            {RankedPosition(x): y for x, y in positions.items()},
+            disqualifications=disqualifications,
+            num_zones=len(expected_points),
+            match_id=(ArenaName('main'), MatchNumber(match_num)),
+        )
+
+        self.assertEqual(expected_points, actual_points, "Wrong points")
+
+    def test_virtual_league_match(self) -> None:
+        self.assertPoints(
+            expected_points={
+                'ABC': 8,
+                'DEF': 6,
+                'GHI': 4,
+                'JKL': 2,
+            },
+            positions={
+                1: ('ABC',),
+                2: ('DEF',),
+                3: ('GHI',),
+                4: ('JKL',),
+            },
+            match_num=0,
+        )
+
+    def test_virtual_league_match_with_tie(self) -> None:
+        self.assertPoints(
+            expected_points={
+                'ABC': 8,
+                'DEF': 5,
+                'GHI': 5,
+                'JKL': 2,
+            },
+            positions={
+                1: ('ABC',),
+                2: ('DEF', 'GHI'),
+                4: ('JKL',),
+            },
+            match_num=0,
+        )
+
+    def test_physical_league_match(self) -> None:
+        self.assertPoints(
+            expected_points={
+                'ABC': 16,
+                'DEF': 12,
+                'GHI': 8,
+                'JKL': 4,
+            },
+            positions={
+                1: ('ABC',),
+                2: ('DEF',),
+                3: ('GHI',),
+                4: ('JKL',),
+            },
+            match_num=50,
+        )
+
+    def test_physical_league_match_with_tie(self) -> None:
+        self.assertPoints(
+            expected_points={
+                'ABC': 16,
+                'DEF': 10,
+                'GHI': 10,
+                'JKL': 4,
+            },
+            positions={
+                1: ('ABC',),
+                2: ('DEF', 'GHI'),
+                4: ('JKL',),
+            },
+            match_num=50,
+        )
+
+    def test_knockouts_match(self) -> None:
+        self.assertPoints(
+            expected_points={
+                'ABC': 16,
+                'DEF': 12,
+                'GHI': 8,
+                'JKL': 4,
+            },
+            positions={
+                1: ('ABC',),
+                2: ('DEF',),
+                3: ('GHI',),
+                4: ('JKL',),
+            },
+            match_num=150,
+        )
+
+    def test_knockouts_match_with_tie(self) -> None:
+        self.assertPoints(
+            expected_points={
+                'ABC': 16,
+                'DEF': 10,
+                'GHI': 10,
+                'JKL': 4,
+            },
+            positions={
+                1: ('ABC',),
+                2: ('DEF', 'GHI'),
+                4: ('JKL',),
+            },
+            match_num=150,
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This relies on changes being introduced in SRComp to enable hooking this as part of the scoring logic, see https://github.com/PeterJCLaw/srcomp/pull/38.

Fixes https://github.com/srobo/tasks/issues/1503