### PR TITLE
Fix detection of errors around highest pallets when zero tokens

### DIFF
--- a/scoring/score.py
+++ b/scoring/score.py
@@ -145,7 +145,7 @@ class Scorer:
         bad_highest2 = {}
         for name, district in self._districts.items():
             highest = district['highest']
-            if highest and highest not in district['pallets']:
+            if highest and not district['pallets'][highest]:
                 bad_highest2[name] = (highest, district['pallets'].keys())
         if bad_highest2:
             detail = "\n".join(

--- a/scoring/tests/test_scoring.py
+++ b/scoring/tests/test_scoring.py
@@ -310,9 +310,17 @@ class ScorerTests(unittest.TestCase):
             code='impossible_highest_pallet',
         )
 
-    def test_highest_when_team_not_present(self) -> None:
+    def test_highest_when_no_pallets_that_zone(self) -> None:
         self.districts['outer_sw']['highest'] = 'Y'
         self.districts['outer_sw']['pallets'] = {'O': 1, 'P': 1}
+        self.assertInvalidScoresheet(
+            self.districts,
+            code='impossible_highest_pallet',
+        )
+
+    def test_highest_when_zero_pallets_that_zone(self) -> None:
+        self.districts['outer_sw']['highest'] = 'Y'
+        self.districts['outer_sw']['pallets'] = {'O': 1, 'P': 1, 'G': 0, 'Y': 0}
         self.assertInvalidScoresheet(
             self.districts,
             code='impossible_highest_pallet',


### PR DESCRIPTION
There was an assumption previously that tokens not present in a district would not be included in the mapping, rather than being included with a zero count. This was incorrect due to how the scorer UI works and not neccesary as we're using a Counter type for this collection. This commit fixes this by handling explicit zeros.

Fixes https://github.com/srobo/sr2025-comp/issues/17