### PR TITLE
Pallets can rest on other tokens not in a district

### DIFF
--- a/scoring/score.py
+++ b/scoring/score.py
@@ -9,12 +9,7 @@ from __future__ import annotations
 import collections
 from typing import Iterable
 
-from sr2025 import (
-    DISTRICT_SCORE_MAP,
-    DISTRICTS_NO_HIGH_RISE,
-    RawDistrict,
-    ZONE_COLOURS,
-)
+from sr2025 import DISTRICT_SCORE_MAP, RawDistrict, ZONE_COLOURS
 
 TOKENS_PER_ZONE = 6
 
@@ -167,25 +162,6 @@ class Scorer:
                 f"-- must be a pallet which is present in the district.\n"
                 f"{detail}",
                 code='impossible_highest_pallet',
-            )
-
-        # Check that the "highest" pallet in districts which don't have a
-        # high-rise has another pallet to be placed on top of (pallets on the
-        # floor don't qualify for being the highest).
-        single_pallet_highest = {}
-        for name in DISTRICTS_NO_HIGH_RISE:
-            district = self._districts[name]
-            highest = district['highest']
-            num_pallets = sum(district['pallets'].values())
-            if num_pallets == 1 and highest:
-                single_pallet_highest[name] = highest
-        if single_pallet_highest:
-            raise InvalidScoresheetException(
-                "Districts without a high-rise and only a single pallet cannot "
-                "have a \"highest\" pallet since pallets on the floor cannot "
-                "count as the highest.\n"
-                f"{single_pallet_highest!r}",
-                code='impossible_highest_single_pallet',
             )
 
         # Check that the total number of pallets of each colour across the whole

--- a/scoring/sr2025.py
+++ b/scoring/sr2025.py
@@ -22,16 +22,7 @@ DISTRICT_SCORE_MAP = {
     'central': 3,
 }
 
-DISTRICTS_NO_HIGH_RISE = frozenset([
-    'outer_nw',
-    'outer_ne',
-    'outer_se',
-    'outer_sw',
-])
-
 DISTRICTS = DISTRICT_SCORE_MAP.keys()
-
-assert DISTRICTS_NO_HIGH_RISE < DISTRICTS
 
 ZONE_COLOURS = (
     'G',    # zone 0 = green

--- a/scoring/tests/test_scoring.py
+++ b/scoring/tests/test_scoring.py
@@ -250,6 +250,19 @@ class ScorerTests(unittest.TestCase):
             self.districts,
         )
 
+    def test_outer_single_token_highest(self) -> None:
+        # Tokens *can* be placed on top of other tokens which themselves aren't
+        # counted as in the zone.
+        self.districts['outer_nw']['highest'] = 'G'
+        self.districts['outer_nw']['pallets'] = {'G': 1}
+        self.assertScores(
+            {
+                'GGG': 2,
+                'OOO': 0,
+            },
+            self.districts,
+        )
+
     # Invalid input
 
     def test_bad_highest_pallet_letter(self) -> None:
@@ -264,14 +277,6 @@ class ScorerTests(unittest.TestCase):
         self.assertInvalidScoresheet(
             self.districts,
             code='invalid_pallets',
-        )
-
-    def test_outer_highest_requires_multiple_tokens_self(self) -> None:
-        self.districts['outer_sw']['highest'] = 'O'
-        self.districts['outer_sw']['pallets'] = {'O': 1}
-        self.assertInvalidScoresheet(
-            self.districts,
-            code='impossible_highest_single_pallet',
         )
 
     def test_missing_district(self) -> None:


### PR DESCRIPTION
This removes the check that districts without high-rises couldn't have a "highest" which had been assumed as there'd be nothing for it to rest on. However such pallets *can* rest on other pallets even if the other pallet isn't counted as "in" the district.