### PR TITLE
Clarify multi-character inputs of pallet counts

### DIFF
--- a/scoring/update.html
+++ b/scoring/update.html
@@ -1,5 +1,15 @@
 {% extends "_update.html" %}
 
+{% block head %}
+    {{ super() }}
+    <style type="text/css">
+        .score-sheet svg input[data-pallets] {
+            letter-spacing: 0;
+            padding: 0.2em 0.1em;
+        }
+    </style>>
+{% endblock %}
+
 {% macro input_highest(x, y, name) %}
     <foreignObject x="{{ x + 5 }}" y="{{ y }}" width="95" height="30">
         <input
@@ -26,6 +36,7 @@
     </foreignObject>
     <foreignObject x="{{ x + 20 }}" y="{{ y }}" width="30" height="30">
         <input
+            data-pallets
             class="pallets tokens"
             type="text"
             id="district_{{ name }}_pallets_{{ colour_symbol }}"


### PR DESCRIPTION
Previously it was easy to input multiple characters (e.g: a two digit number) and not realise this was the case. This uses a data attribute, rather than classes since the latter didn't seem to work :(

**Before**: 
![image](https://github.com/user-attachments/assets/c1b52ee2-e85e-479c-9db6-c5bd55c4bd27)
**After**:
![image](https://github.com/user-attachments/assets/fbd49680-5076-45a8-920d-74d85ac431b4)
